### PR TITLE
Move submodules to unauthenticated urls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "submodules/smufl"]
 	path = submodules/smufl
-	url = git@github.com:w3c/smufl.git
+	url = https://github.com/w3c/smufl.git
 [submodule "submodules/bravura"]
 	path = submodules/bravura
-	url = git@github.com:steinbergmedia/bravura.git
+	url = https://github.com/steinbergmedia/bravura.git
 [submodule "submodules/petaluma"]
 	path = submodules/petaluma
 	url = https://github.com/steinbergmedia/petaluma.git


### PR DESCRIPTION
I'm not sure you're actually interested in contributions at this point but I was playing with the project and noticed that the submodules are using urls which require authentication. This PR moves them to public urls so it's easier to clone and bulid the repo.